### PR TITLE
Move PathFinderReturn to fix compile error

### DIFF
--- a/Traveler.ts
+++ b/Traveler.ts
@@ -632,13 +632,6 @@ export class Traveler {
     }
 }
 
-interface PathfinderReturn {
-    path: RoomPosition[];
-    ops: number;
-    cost: number;
-    incomplete: boolean;
-}
-
 // this might be higher than you wish, setting it lower is a great way to diagnose creep behavior issues. When creeps
 // need to repath to often or they aren't finding valid paths, it can sometimes point to problems elsewhere in your code
 const REPORT_CPU_THRESHOLD = 1000;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,10 @@
+interface PathfinderReturn {
+    path: RoomPosition[];
+    ops: number;
+    cost: number;
+    incomplete: boolean;
+}
+
 interface TravelToReturnData {
     nextPos?: RoomPosition;
     pathfinderReturn?: PathfinderReturn;


### PR DESCRIPTION
PathfinderReturn moved to index.d.ts in order to eliminate error during compilation. 

Along with PR #112 in screeps-typescript-declarations this ensures Traveller can be used as a submodule - in its current state - in a TS project without introducing errors. 