### PR TITLE
Remove typings, use screepers/typed-screeps

### DIFF
--- a/dist/Traveler.d.ts
+++ b/dist/Traveler.d.ts
@@ -1,7 +1,16 @@
+/// <reference types="typed-screeps" />
 /**
  * To start using Traveler, require it in main.js:
  * Example: var Traveler = require('Traveler.js');
  */
+declare global  {
+    interface CreepMemory {
+        _trav?: TravelData;
+    }
+    interface RoomMemory {
+        avoid?: number;
+    }
+}
 export declare class Traveler {
     private static structureMatrixCache;
     private static creepMatrixCache;
@@ -27,7 +36,7 @@ export declare class Traveler {
      * @param roomName
      * @returns {RoomMemory|number}
      */
-    static checkAvoid(roomName: string): any;
+    static checkAvoid(roomName: string): number;
     /**
      * check if a position is an exit
      * @param pos
@@ -210,3 +219,4 @@ export declare type Coord = {
 export declare type HasPos = {
     pos: RoomPosition;
 };
+export {};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "Traveler",
   "version": "0.0.1",
   "main": "./dist/Traveler.js",
-  "types": "./declarations/Traveler.d.ts",
+  "types": "./dist/Traveler.d.ts",
   "devDependencies": {
     "@types/lodash": "^3.10.1",
     "typed-screeps": "github:screepers/typed-screeps"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "types": "./dist/Traveler.d.ts",
   "devDependencies": {
     "@types/lodash": "^3.10.1",
-    "typed-screeps": "github:screepers/typed-screeps"
+    "typed-screeps": "^1.0.3"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "main": "./dist/Traveler.js",
   "types": "./declarations/Traveler.d.ts",
   "devDependencies": {
-    "@types/lodash": "^3.10.0"
+    "@types/lodash": "^3.10.1",
+    "typed-screeps": "github:screepers/typed-screeps"
   },
-  "dependencies": {
-    "typings": "^2.1.1"
-  }
+  "dependencies": {}
 }

--- a/src/Traveler.ts
+++ b/src/Traveler.ts
@@ -3,6 +3,16 @@
  * Example: var Traveler = require('Traveler.js');
  */
 
+declare global {
+    interface CreepMemory {
+        _trav?: TravelData;
+    }
+
+    interface RoomMemory {
+        avoid?: number;
+    }
+}
+
 export class Traveler {
 
     private static structureMatrixCache: {[roomName: string]: CostMatrix} = {};
@@ -37,7 +47,7 @@ export class Traveler {
 
         // initialize data object
         if (!creep.memory._trav) {
-            creep.memory._trav = {};
+            creep.memory._trav = {} as TravelData;
         }
         let travelData = creep.memory._trav as TravelData;
 
@@ -162,7 +172,7 @@ export class Traveler {
             options.returnData.state = state;
             options.returnData.path = travelData.path;
         }
-        return creep.move(nextDirection);
+        return creep.move(nextDirection as DirectionConstant);
     }
 
     /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,13 @@
     "sourceMap": false,
     "declaration": true,
     "declarationDir": "./dist",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "types": ["lodash", "typed-screeps"]
   },
   "exclude": [
     "node_modules"
+  ],
+  "include": [
+    "./src/**/*.ts"
   ]
 }

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,0 @@
-{
-  "globalDependencies": {
-    "screeps": "github:screepers/Screeps-Typescript-Declarations/dist/screeps.d.ts"
-  }
-}


### PR DESCRIPTION
[typed-screeps](https://github.com/screepers/typed-screeps) (the stricter definitions) now work without needing typings, so this PR switches to using them. This does require a couple small changes - casts and interface merging - but it doesn't affect behavior at all.

This PR also fixes a typo in `package.json` in the `types` path.