### PR TITLE
Fix bug where creep can stop in different room from destinatino

### DIFF
--- a/src/Traveler.ts
+++ b/src/Traveler.ts
@@ -287,6 +287,12 @@ export class Traveler {
         destination = this.normalizePos(destination);
         let originRoomName = origin.roomName;
         let destRoomName = destination.roomName;
+        
+        // Prevents creeps from stopping in a different room
+        let distanceToEdge = _.min([destination.x, 49 - destination.x, destination.y, 49 - destination.y]);
+        if (distanceToEdge < options.range!) {
+            options.range = distanceToEdge - 1;
+        }
 
         // check to see whether findRoute should be used
         let roomDistance = Game.map.getRoomLinearDistance(origin.roomName, destination.roomName);


### PR DESCRIPTION
Ensures creep won't stop in a different room or idle on a room edge when traveling to a target near an exit

Fixes #1 